### PR TITLE
Adding a config option to disable stress for all players

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -794,29 +794,31 @@ RegisterNetEvent('hud:client:OnMoneyChange', function(type, amount, isMinus)
 end)
 
 -- Stress Gain
-CreateThread(function() -- Speeding
-    while true do
-        if LocalPlayer.state.isLoggedIn then
-            if cache.vehicle then
-                local vehClass = GetVehicleClass(cache.vehicle)
-                local speed = GetEntitySpeed(cache.vehicle) * speedMultiplier
+if not config.stress.disableStress then
+    CreateThread(function() -- Speeding
+        while true do
+            if LocalPlayer.state.isLoggedIn then
+                if cache.vehicle then
+                    local vehClass = GetVehicleClass(cache.vehicle)
+                    local speed = GetEntitySpeed(cache.vehicle) * speedMultiplier
 
-                if vehClass ~= 13 and vehClass ~= 14 and vehClass ~= 15 and vehClass ~= 16 and vehClass ~= 21 then
-                    local stressSpeed
-                    if vehClass == 8 then
-                        stressSpeed = config.stress.minForSpeeding
-                    else
-                        stressSpeed = LocalPlayer.state?.seatbelt and config.stress.minForSpeeding or config.stress.minForSpeedingUnbuckled
-                    end
-                    if speed >= stressSpeed then
-                        TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
+                    if vehClass ~= 13 and vehClass ~= 14 and vehClass ~= 15 and vehClass ~= 16 and vehClass ~= 21 then
+                        local stressSpeed
+                        if vehClass == 8 then
+                            stressSpeed = config.stress.minForSpeeding
+                        else
+                            stressSpeed = LocalPlayer.state?.seatbelt and config.stress.minForSpeeding or config.stress.minForSpeedingUnbuckled
+                        end
+                        if speed >= stressSpeed then
+                            TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
+                        end
                     end
                 end
             end
+            Wait(10000)
         end
-        Wait(10000)
-    end
-end)
+    end)
+end
 
 local function isWhitelistedWeaponStress(weapon)
     if weapon then

--- a/client/main.lua
+++ b/client/main.lua
@@ -794,7 +794,7 @@ RegisterNetEvent('hud:client:OnMoneyChange', function(type, amount, isMinus)
 end)
 
 -- Stress Gain
-if not config.stress.disableStress then
+if config.stress.enableStress then
     CreateThread(function() -- Speeding
         while true do
             if LocalPlayer.state.isLoggedIn then

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,7 +1,7 @@
 return {
     menuKey = 'I', -- Key to open the HUD menu
     useMPH = true, -- If true, speed math will be done as MPH, if false KPH will be used (YOU HAVE TO CHANGE CONTENT IN STYLES.CSS TO DISPLAY THE CORRECT TEXT)
-    
+
     stress = {
         chance = 0.1, -- Percentage stress chance when shooting (0-1)
         minForShaking = 50, -- Minimum stress level for screen shaking
@@ -68,5 +68,4 @@ return {
         `weapon_smokegrenade`,
         `weapon_flare`,
     },
-
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,6 +1,5 @@
 return {
     stress = {
         disableForLEO = true, -- If true, it will disable stress for people in the leo job type
-        disableStress = false, -- If true, it will disable stress for everyone
     },
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,5 +1,6 @@
 return {
     stress = {
         disableForLEO = true, -- If true, it will disable stress for people in the leo job type
+        disableStress = true, -- If true, it will disable stress for everyone
     },
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,6 +1,6 @@
 return {
     stress = {
         disableForLEO = true, -- If true, it will disable stress for people in the leo job type
-        disableStress = true, -- If true, it will disable stress for everyone
+        disableStress = false, -- If true, it will disable stress for everyone
     },
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,4 +1,8 @@
 return {
+    stress = {
+        enableStress = true, -- If false, it will disable stress for everyone
+    },
+
     menu = { -- Don't touch
         isOutMapChecked = false, -- isOutMapChecked
         isOutCompassChecked = false, -- isOutMapChecked

--- a/server/main.lua
+++ b/server/main.lua
@@ -21,7 +21,8 @@ end)
 -- Network Events
 
 RegisterNetEvent('hud:server:GainStress', function(amount)
-    if config.stress.disableStress then return end
+    if not config.stress.enableStress then return end
+
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
     local newStress
@@ -44,7 +45,8 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
 end)
 
 RegisterNetEvent('hud:server:RelieveStress', function(amount)
-    if config.stress.disableStress then return end
+    if not config.stress.enableStress then return end
+
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
     local newStress

--- a/server/main.lua
+++ b/server/main.lua
@@ -21,6 +21,7 @@ end)
 -- Network Events
 
 RegisterNetEvent('hud:server:GainStress', function(amount)
+    if config.stress.disableStress then return end
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
     local newStress
@@ -43,6 +44,7 @@ RegisterNetEvent('hud:server:GainStress', function(amount)
 end)
 
 RegisterNetEvent('hud:server:RelieveStress', function(amount)
+    if config.stress.disableStress then return end
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
     local newStress


### PR DESCRIPTION
## Description

This change simply adds an option for server owners to disable stress for everyone in the server

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
