### PR TITLE
fix(client/main): comparing name with hash

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -858,7 +858,7 @@ AddEventHandler('ox_inventory:currentWeapon', function(currentWeapon)
 
     if not currentWeapon then return end
 
-    startWeaponStressThread(currentWeapon.name)
+    startWeaponStressThread(currentWeapon.hash)
 end)
 
 -- Stress Screen Effects


### PR DESCRIPTION
## Description

We're currently comparing the weapon hashes in `whitelistedWeapons` or `weaponsArmedMode` with the weapon name. We should be comparing the weapon hashes with the current weapon hash. This fixes that.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
