### PR TITLE
fix: validate stress event amounts

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -4,6 +4,12 @@ local config = require 'config.server'
 local sharedConfig = require 'config.shared'
 local resetStress = false
 
+---@param amount any
+---@return boolean
+local function isValidStressAmount(amount)
+    return type(amount) == 'number' and amount == amount and amount > 0 and amount <= 100
+end
+
 -- Handlers
 
 AddEventHandler('ox_inventory:openedInventory', function(source)
@@ -24,6 +30,7 @@ end)
 
 RegisterNetEvent('hud:server:GainStress', function(amount)
     if not sharedConfig.stress.enableStress then return end
+    if not isValidStressAmount(amount) then return end
 
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
@@ -48,6 +55,7 @@ end)
 
 RegisterNetEvent('hud:server:RelieveStress', function(amount)
     if not sharedConfig.stress.enableStress then return end
+    if not isValidStressAmount(amount) then return end
 
     local src = source
     local player = exports.qbx_core:GetPlayer(src)


### PR DESCRIPTION
## What changed
- reject non-numeric, NaN, non-positive, and oversized stress event amounts
- apply the same boundary to gain and relief events

## Why
Network event arguments were used directly in metadata arithmetic. A client could send negative or non-finite values to invert the operation or poison stress state.

## Validation
- git diff --check
- direct Lua control-flow and boundary review