### PR TITLE
fix calling a table value

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -132,11 +132,10 @@ RegisterNUICallback('restartHud', function(_, cb)
     cb('ok')
 end)
 
-RegisterCommand('resethud', function(_, cb)
+RegisterCommand('resethud', function()
     Wait(50)
     restartHud()
-    cb('ok')
-end)
+end, false)
 
 RegisterNUICallback('resetStorage', function(_, cb)
     Wait(50)


### PR DESCRIPTION
there is no `cb` in RegisterCommand

## Description

fixes the error when using the command, there is no callback in RegisterCommand

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change

## Testing

<!-- How did you test this? What did you verify? -->

## Checklist

- [x] I tested this on a local Qbox server
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] My changes follow the [contribution guidelines](https://github.com/Qbox-project/.github/blob/main/.github/contributing.md)
- [x] I fixed any lint issues reported by CI
